### PR TITLE
Allow more versions of Elixir.

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Brainfuck.Mixfile do
   def project do
     [app: :brainfuck,
      version: "0.0.1",
-     elixir: "~> 1.0.0",
+     elixir: "~> 1.0",
      escript: escript,
      deps: deps]
   end


### PR DESCRIPTION
This allows my current version of Elixir (1.6.4) and, if my understanding is correct, should allow all versions up to 2.0. The tests still pass, so I assume this is fine.

```exs
Brainfuck.VM.run(Brainfuck.Compiler.compile("++++++++++[>+++++++>++++++++++>+++>+<<<<-]>++.>+.+++++++..+++.>++.<<+++++++++++++++.>.+++.------.--------.>+.>."))
#=> {4, [0, 87, 100, 33, 10], [:stdio], 'Hello World!\n'}
```

Well, hello world seems to work too! Very cool.